### PR TITLE
update to attoparsec-0.10-*

### DIFF
--- a/Data/Time/Parsers/Date.hs
+++ b/Data/Time/Parsers/Date.hs
@@ -13,18 +13,17 @@ module Data.Time.Parsers.Date ( yyyymmdd
                               , defaultDayCE
                               ) where
 
-import Data.Time.Parsers.Util
-import Data.Time.Parsers.Tables        (weekdays, months)
+import           Data.Time.Parsers.Util
+import           Data.Time.Parsers.Tables (weekdays, months)
 
-import Control.Applicative             ((<$>),(<*>),(<|>))
-import Control.Monad.Reader
-import Data.Attoparsec.Char8
-import Data.Attoparsec.FastSet
-import qualified Data.ByteString.Char8 as B
-import Data.Char                       (toLower)
-import Data.Map                        as M hiding (map)
-import Data.Time
-import Prelude                         hiding (takeWhile)
+import           Control.Applicative      ((<$>),(<*>),(<|>))
+import           Control.Monad.Reader
+import           Data.Attoparsec.Char8
+import qualified Data.ByteString.Char8    as B
+import           Data.Char                (toLower)
+import           Data.Map                 as M hiding (map)
+import           Data.Time
+import           Prelude                  hiding (takeWhile)
 
 
 lookupMonth :: B.ByteString -> Maybe Integer
@@ -147,10 +146,10 @@ tokenizedDate = do
     m <- isFlagSet MakeRecent
     lift $ tokenizedDate' s f m
 
-tokenizedDate' :: FastSet -> [DateFormat] -> Bool -> Parser Day
+tokenizedDate' :: String -> [DateFormat] -> Bool -> Parser Day
 tokenizedDate' seps' formats' makeRecent' = do
     a   <- dateToken
-    sep <- satisfy $ flip memberChar seps'
+    sep <- satisfy $ inClass seps'
     b   <- dateToken
     _   <- satisfy (==sep)
     c   <- numericDateToken
@@ -191,13 +190,13 @@ yearDayOfYear = do
     s <- asks seps
     lift $ yearDayOfYear' s
 
-yearDayOfYear' :: FastSet -> Parser Day
+yearDayOfYear' :: String -> Parser Day
 yearDayOfYear' seps' = do
     year <- nDigit 4
     day  <- maybeSep >> nDigit 3
     yearDayToDate year day
   where
-    maybeSep = option () $ satisfy (flip memberChar seps') >> return ()
+    maybeSep = option () $ satisfy (inClass seps') >> return ()
 
 -- | parse a julian day (days since 4713/1/1 BCE)
 -- Must prepend with "J", "JD", or "Julian"

--- a/Data/Time/Parsers/Types.hs
+++ b/Data/Time/Parsers/Types.hs
@@ -6,7 +6,6 @@ module Data.Time.Parsers.Types where
 
 import Control.Monad.Reader        (ReaderT)
 import Data.Attoparsec.Char8       (Parser)
-import Data.Attoparsec.FastSet     (FastSet)
 import Data.Convertible
 import Data.Convertible.Instances()
 import qualified Data.Set          as Set
@@ -75,7 +74,7 @@ data Flag
 
 data Options =
     Options { formats :: [DateFormat] -- ^ List of what DateFormats to try.
-            , seps    :: FastSet      -- ^ Set of accepted separators
+            , seps    :: String       -- ^ Set of accepted separators
             , flags   :: Set.Set Flag -- ^ Set of Flags
             }
 

--- a/Data/Time/Parsers/Util.hs
+++ b/Data/Time/Parsers/Util.hs
@@ -18,15 +18,14 @@ module Data.Time.Parsers.Util ( nDigit
                               , module Data.Time.Parsers.Types
                               ) where
 
-import Data.Time.Parsers.Types
+import           Data.Time.Parsers.Types
 
-import Control.Applicative               ((<|>),(<$>),(<*),(*>))
-import Control.Monad.Reader
-import Data.Attoparsec.Char8
-import Data.Attoparsec.FastSet              (set)
+import           Control.Applicative     ((<|>),(<$>),(<*),(*>))
+import           Control.Monad.Reader
+import           Data.Attoparsec.Char8
 import qualified Data.ByteString.Char8   as B
-import Data.Set                          as Set (member, fromList)
-import Data.Time
+import           Data.Set                as Set (member, fromList)
+import           Data.Time
 
 -- | Parse a given number of digits
 nDigit :: (Read a, Num a) => Int -> Parser a
@@ -48,7 +47,7 @@ onlyParse p = p <* lift endOfInput
 -- Use flags MakeRecent, DefaultToUTC, DefaultToMidnight
 defaultOptions :: Options
 defaultOptions = Options { formats = [YMD,MDY,DMY]
-                         , seps = set ". /-"
+                         , seps = ". /-"
                          , flags = Set.fromList [ MakeRecent
                                                 , DefaultToUTC
                                                 , DefaultToMidnight

--- a/timeparsers.cabal
+++ b/timeparsers.cabal
@@ -1,5 +1,5 @@
 Name:                timeparsers
-Version:             0.1
+Version:             0.2
 Synopsis:            Attoparsec parsers for various Date/Time formats.
 License:             BSD3
 License-file:        LICENSE
@@ -27,8 +27,8 @@ Library
   Build-depends:
         base,
         bytestring,
-        attoparsec,
+        attoparsec == 0.10.*,
         time,
         mtl,
-        convertible,
-        containers
+        convertible == 1.0.*,
+        containers >= 0.3 && < 0.5


### PR DESCRIPTION
this requires some tweaks to work with attoparsec-0.10, which doesn't export
FastSet anymore.
