### PR TITLE
Update cabal file with incremented versions.

### DIFF
--- a/timeparsers.cabal
+++ b/timeparsers.cabal
@@ -30,9 +30,9 @@ Library
         Data.Time.Parsers.Util
   Build-depends:
         base >= 4 && < 5,
-        bytestring >= 0.9.1 && < 0.10,
+        bytestring >= 0.9.1 && < 0.11,
         attoparsec >= 0.9.1.2 && < 0.11,
-        time >= 1.0 && < 1.3,
-        mtl >= 2.0.1 && <= 2.1,
+        time >= 1.0 && < 1.5,
+        mtl >= 2.0.1 && <= 2.2,
         convertible >= 1.0 && < 1.1,
-        containers >= 0.3 && < 0.5
+        containers >= 0.3 && < 0.5.1


### PR DESCRIPTION
I tried to increment versions on as few things as possible and as little as possible, but the general policy was just to increment the last digit in the version number. The except was when the new version was several increments beyond the constraint, in which case I set the cabal restriction to one greater than the last digit of the newer version.
